### PR TITLE
Build tag refactor.

### DIFF
--- a/webapp.go
+++ b/webapp.go
@@ -19,6 +19,9 @@ import (
 	"net/http"
 )
 
+// IsDev whether the application is running in the development mode.
+var IsDev = isDev
+
 // PolyserveURLs are the URLs we should proxy to polymer serve
 var PolyserveURLs = []string{
 	"/node_modules/",
@@ -49,4 +52,9 @@ func HSTSHandler(f http.HandlerFunc) http.HandlerFunc {
 			"max-age=63072000; includeSubDomains; preload")
 		f(w, r)
 	})
+}
+
+// InitPolyserveProxy initializes a proxy for 'polymer serve'
+func InitPolyserveProxy(mux *http.ServeMux, URL string) error {
+	return initPolyserveProxy(mux, URL)
 }

--- a/webapp_appengine.go
+++ b/webapp_appengine.go
@@ -25,11 +25,9 @@ import (
 	"google.golang.org/appengine/urlfetch"
 )
 
-// IsDev whether the application is running in the development mode.
-var IsDev = appengine.IsDevAppServer()
+var isDev = appengine.IsDevAppServer()
 
-// InitPolyserveProxy initializes a proxy for 'polymer serve'
-func InitPolyserveProxy(mux *http.ServeMux, URL string) error {
+func initPolyserveProxy(mux *http.ServeMux, URL string) error {
 	for _, path := range PolyserveURLs {
 		mux.HandleFunc(path, makeProxy(URL))
 	}

--- a/webapp_noappengine.go
+++ b/webapp_noappengine.go
@@ -22,11 +22,9 @@ import (
 	"net/url"
 )
 
-// IsDev whether the application is running in the development mode.
-var IsDev = false
+var isDev = false
 
-// InitPolyserveProxy initializes a proxy for 'polymer serve'
-func InitPolyserveProxy(mux *http.ServeMux, URL string) error {
+func initPolyserveProxy(mux *http.ServeMux, URL string) error {
 	backend, err := url.Parse(URL)
 	if nil != err {
 		return err


### PR DESCRIPTION
Changed the source code structure, make _appengine and _noappengine
implement private methods so that all public methods can be found
clearly listed in the webapp.go file.