### PR TITLE
Bugfix in CreateCustom

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,7 +23,10 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: qqiao/dev-env
+    runs-on: ubuntu-latest
+    container:
+      image: qqiao/dev-env:latest
+      options: --user root
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -63,8 +63,7 @@ jobs:
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
 
-    - run: |
-      go build .
+    - run: go build .
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: qqiao/dev-env
     permissions:
       actions: read
       contents: read
@@ -53,8 +53,8 @@ jobs:
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+    # - name: Autobuild
+    #  uses: github/codeql-action/autobuild@v1
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -63,9 +63,8 @@ jobs:
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
 
-    #- run: |
-    #   make bootstrap
-    #   make release
+    - run: |
+      go build .
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/qqiao/webapp
 
-go 1.12
+go 1.16
 
-require github.com/golang-jwt/jwt/v4 v4.4.0
+retract v1.4.0
+
+require github.com/golang-jwt/jwt/v4 v4.4.1

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/golang-jwt/jwt/v4 v4.4.0 h1:EmVIxB5jzbllGIjiCV5JG4VylbK3KE400tLGLI1cdfU=
 github.com/golang-jwt/jwt/v4 v4.4.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
+github.com/golang-jwt/jwt/v4 v4.4.1 h1:pC5DB52sCeK48Wlb9oPcdhnjkz1TKt1D/P7WKJ0kUcQ=
+github.com/golang-jwt/jwt/v4 v4.4.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=

--- a/jwt/manager.go
+++ b/jwt/manager.go
@@ -80,7 +80,7 @@ func (m Manager) CreateCustom(dat interface{},
 	expiresAt *time.Time) (<-chan string, <-chan error) {
 	_expiresAt := time.Now().Add(365 * 24 * time.Hour)
 	if expiresAt != nil {
-		_expiresAt = time.Unix(expiresAt.Unix(), expiresAt.UnixMicro())
+		_expiresAt = time.Unix(expiresAt.Unix(), 0)
 	}
 
 	claims := NewClaims().WithDat(dat).WithExpiry(_expiresAt)


### PR DESCRIPTION
Fixed a bug in create custom where when no expiresAt is specified,
the default expiresAt creation had two issues:

* It used a go1.17 API time.UnixMicro, wihch breaks backward
  compatibility

* The function was used wrongly as the 2nd param of time.Unix()

As a result of this, we have to issue this fix to ensure that the
1.4 stream still works with old version of the Go language. And we
also have to retract the v1.4.0 release.