### PR TITLE
Fixed documentation error in the PS512Manager example.

### DIFF
--- a/jwt/manager_test.go
+++ b/jwt/manager_test.go
@@ -27,7 +27,7 @@ import (
 
 func ExampleNewPS512Manager() {
 	// In real program usage, the private and public key pair has to be real
-	// and should be dummy ones like this
+	// and should not be dummy ones like this
 	privateKey := &rsa.PrivateKey{}
 	publicKey := &rsa.PublicKey{}
 


### PR DESCRIPTION
In the PS512Manager example, it should read "In real program usage,
the private and public key pair has to be real and should not be
dummy ones like this". The word "not" was missing and the meaning
was completely wrong.